### PR TITLE
Investigate user record removal from views

### DIFF
--- a/BuffetAbogados/src/main/java/vista/Dashboard.java
+++ b/BuffetAbogados/src/main/java/vista/Dashboard.java
@@ -1,0 +1,321 @@
+package buffetabogados.vista;
+
+import buffetabogados.modelo.Usuario;
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/**
+ * Dashboard principal del sistema - Ventana principal después del login
+ */
+public class Dashboard extends JFrame {
+    
+    private Usuario usuarioActual;
+    private JLabel lblBienvenida;
+    private JMenuBar menuBar;
+    
+    // Paneles principales
+    private JPanel panelPrincipal;
+    private JPanel panelModulos;
+    private JPanel panelEstadisticas;
+    
+    // Botones de módulos
+    private JButton btnClientes;
+    private JButton btnEmpleados;
+    private JButton btnCasos;
+    private JButton btnAudiencias;
+    private JButton btnReportes;
+    private JButton btnConfiguracion;
+    
+    public Dashboard(Usuario usuario) {
+        this.usuarioActual = usuario;
+        
+        configurarVentana();
+        inicializarComponentes();
+        configurarLayout();
+        configurarEventos();
+        aplicarPermisosSegunRol();
+        
+        setVisible(true);
+    }
+    
+    private void configurarVentana() {
+        setTitle("Buffet de Abogados - Dashboard");
+        setSize(1000, 700);
+        setLocationRelativeTo(null);
+        setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        setExtendedState(JFrame.MAXIMIZED_BOTH);
+        
+        // Configurar look and feel
+        try {
+            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeel());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+    
+    private void inicializarComponentes() {
+        // Menu Bar
+        menuBar = new JMenuBar();
+        
+        // Menu Sistema
+        JMenu menuSistema = new JMenu("Sistema");
+        JMenuItem itemCerrarSesion = new JMenuItem("Cerrar Sesión");
+        JMenuItem itemSalir = new JMenuItem("Salir");
+        menuSistema.add(itemCerrarSesion);
+        menuSistema.addSeparator();
+        menuSistema.add(itemSalir);
+        
+        // Menu Gestión
+        JMenu menuGestion = new JMenu("Gestión");
+        JMenuItem itemClientes = new JMenuItem("Clientes");
+        JMenuItem itemEmpleados = new JMenuItem("Empleados");
+        JMenuItem itemCasos = new JMenuItem("Casos");
+        JMenuItem itemAudiencias = new JMenuItem("Audiencias");
+        menuGestion.add(itemClientes);
+        menuGestion.add(itemEmpleados);
+        menuGestion.add(itemCasos);
+        menuGestion.add(itemAudiencias);
+        
+        // Menu Reportes
+        JMenu menuReportes = new JMenu("Reportes");
+        JMenuItem itemReporteClientes = new JMenuItem("Reporte de Clientes");
+        JMenuItem itemReporteCasos = new JMenuItem("Reporte de Casos");
+        JMenuItem itemReporteGeneral = new JMenuItem("Reporte General");
+        menuReportes.add(itemReporteClientes);
+        menuReportes.add(itemReporteCasos);
+        menuReportes.add(itemReporteGeneral);
+        
+        // Menu Ayuda
+        JMenu menuAyuda = new JMenu("Ayuda");
+        JMenuItem itemAcercaDe = new JMenuItem("Acerca de");
+        menuAyuda.add(itemAcercaDe);
+        
+        menuBar.add(menuSistema);
+        menuBar.add(menuGestion);
+        menuBar.add(menuReportes);
+        menuBar.add(menuAyuda);
+        
+        setJMenuBar(menuBar);
+        
+        // Labels principales
+        lblBienvenida = new JLabel("Bienvenido, " + usuarioActual.getNombreCompleto());
+        lblBienvenida.setFont(new Font("Arial", Font.BOLD, 18));
+        lblBienvenida.setForeground(new Color(0, 102, 204));
+        
+        // Botones de módulos
+        btnClientes = crearBotonModulo("👥 Gestión de Clientes", 
+            "Registrar, editar y consultar información de clientes", new Color(52, 152, 219));
+        btnEmpleados = crearBotonModulo("👨‍💼 Gestión de Empleados", 
+            "Administrar información del personal", new Color(46, 204, 113));
+        btnCasos = crearBotonModulo("📋 Gestión de Casos", 
+            "Crear y dar seguimiento a casos legales", new Color(155, 89, 182));
+        btnAudiencias = crearBotonModulo("⚖️ Gestión de Audiencias", 
+            "Programar y administrar audiencias", new Color(230, 126, 34));
+        btnReportes = crearBotonModulo("📊 Reportes", 
+            "Generar reportes del sistema", new Color(231, 76, 60));
+        btnConfiguracion = crearBotonModulo("⚙️ Configuración", 
+            "Configurar conexión y parámetros del sistema", new Color(149, 165, 166));
+        
+        // Eventos de menú
+        itemCerrarSesion.addActionListener(e -> cerrarSesion());
+        itemSalir.addActionListener(e -> System.exit(0));
+        itemClientes.addActionListener(e -> abrirGestionClientes());
+        itemEmpleados.addActionListener(e -> abrirGestionEmpleados());
+        itemCasos.addActionListener(e -> abrirGestionCasos());
+        itemAudiencias.addActionListener(e -> abrirGestionAudiencias());
+        itemReporteClientes.addActionListener(e -> generarReporteClientes());
+        itemReporteCasos.addActionListener(e -> generarReporteCasos());
+        itemReporteGeneral.addActionListener(e -> generarReporteGeneral());
+        itemAcercaDe.addActionListener(e -> mostrarAcercaDe());
+    }
+    
+    private JButton crearBotonModulo(String titulo, String descripcion, Color color) {
+        JButton boton = new JButton();
+        boton.setLayout(new BorderLayout());
+        boton.setPreferredSize(new Dimension(280, 120));
+        boton.setBackground(color);
+        boton.setForeground(Color.WHITE);
+        boton.setFocusPainted(false);
+        boton.setBorder(BorderFactory.createRaisedBevelBorder());
+        
+        // Título del botón
+        JLabel lblTitulo = new JLabel(titulo);
+        lblTitulo.setFont(new Font("Arial", Font.BOLD, 14));
+        lblTitulo.setForeground(Color.WHITE);
+        lblTitulo.setHorizontalAlignment(SwingConstants.CENTER);
+        
+        // Descripción del botón
+        JLabel lblDescripcion = new JLabel("<html><center>" + descripcion + "</center></html>");
+        lblDescripcion.setFont(new Font("Arial", Font.PLAIN, 10));
+        lblDescripcion.setForeground(Color.WHITE);
+        lblDescripcion.setHorizontalAlignment(SwingConstants.CENTER);
+        
+        boton.add(lblTitulo, BorderLayout.CENTER);
+        boton.add(lblDescripcion, BorderLayout.SOUTH);
+        
+        // Efecto hover
+        boton.addMouseListener(new java.awt.event.MouseAdapter() {
+            public void mouseEntered(java.awt.event.MouseEvent evt) {
+                boton.setBackground(color.brighter());
+            }
+            public void mouseExited(java.awt.event.MouseEvent evt) {
+                boton.setBackground(color);
+            }
+        });
+        
+        return boton;
+    }
+    
+    private void configurarLayout() {
+        setLayout(new BorderLayout());
+        
+        // Panel superior
+        JPanel panelSuperior = new JPanel(new BorderLayout());
+        panelSuperior.setBorder(BorderFactory.createEmptyBorder(15, 20, 15, 20));
+        panelSuperior.setBackground(Color.WHITE);
+        
+        // Información del usuario
+        JPanel panelUsuario = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        panelUsuario.setBackground(Color.WHITE);
+        panelUsuario.add(lblBienvenida);
+        
+        JLabel lblRol = new JLabel("Rol: " + usuarioActual.getRol());
+        lblRol.setFont(new Font("Arial", Font.PLAIN, 12));
+        lblRol.setForeground(Color.GRAY);
+        panelUsuario.add(lblRol);
+        
+        // Fecha y hora
+        JLabel lblFecha = new JLabel(java.time.LocalDateTime.now().format(
+            java.time.format.DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm")));
+        lblFecha.setFont(new Font("Arial", Font.PLAIN, 12));
+        lblFecha.setForeground(Color.GRAY);
+        
+        panelSuperior.add(panelUsuario, BorderLayout.WEST);
+        panelSuperior.add(lblFecha, BorderLayout.EAST);
+        
+        // Panel central con módulos
+        panelModulos = new JPanel(new GridLayout(2, 3, 20, 20));
+        panelModulos.setBorder(BorderFactory.createEmptyBorder(20, 50, 20, 50));
+        panelModulos.setBackground(new Color(236, 240, 241));
+        
+        panelModulos.add(btnClientes);
+        panelModulos.add(btnEmpleados);
+        panelModulos.add(btnCasos);
+        panelModulos.add(btnAudiencias);
+        panelModulos.add(btnReportes);
+        panelModulos.add(btnConfiguracion);
+        
+        // Panel de estadísticas (simple)
+        panelEstadisticas = new JPanel(new FlowLayout());
+        panelEstadisticas.setBackground(new Color(52, 73, 94));
+        panelEstadisticas.setBorder(BorderFactory.createEmptyBorder(10, 20, 10, 20));
+        
+        JLabel lblEstadisticas = new JLabel("📊 Dashboard - Sistema de Gestión Legal");
+        lblEstadisticas.setForeground(Color.WHITE);
+        lblEstadisticas.setFont(new Font("Arial", Font.BOLD, 12));
+        panelEstadisticas.add(lblEstadisticas);
+        
+        add(panelSuperior, BorderLayout.NORTH);
+        add(panelModulos, BorderLayout.CENTER);
+        add(panelEstadisticas, BorderLayout.SOUTH);
+    }
+    
+    private void configurarEventos() {
+        btnClientes.addActionListener(e -> abrirGestionClientes());
+        btnEmpleados.addActionListener(e -> abrirGestionEmpleados());
+        btnCasos.addActionListener(e -> abrirGestionCasos());
+        btnAudiencias.addActionListener(e -> abrirGestionAudiencias());
+        btnReportes.addActionListener(e -> abrirReportes());
+        btnConfiguracion.addActionListener(e -> abrirConfiguracion());
+    }
+    
+    private void aplicarPermisosSegunRol() {
+        if (usuarioActual.esCliente()) {
+            // Los clientes solo pueden ver sus casos y reportes
+            btnEmpleados.setEnabled(false);
+            btnConfiguracion.setEnabled(false);
+            
+            btnClientes.setText("👤 Mi Perfil");
+            btnCasos.setText("📋 Mis Casos");
+            btnReportes.setText("📊 Mis Reportes");
+            
+            // Ocultar botones no permitidos
+            btnEmpleados.setVisible(false);
+            btnConfiguracion.setVisible(false);
+        }
+    }
+    
+    // Métodos de acción para cada módulo
+    private void abrirGestionClientes() {
+        new GestionClientes();
+    }
+    
+    private void abrirGestionEmpleados() {
+        JOptionPane.showMessageDialog(this,
+            "Módulo de Gestión de Empleados\n(En desarrollo)",
+            "Información", JOptionPane.INFORMATION_MESSAGE);
+    }
+    
+    private void abrirGestionCasos() {
+        JOptionPane.showMessageDialog(this,
+            "Módulo de Gestión de Casos\n(En desarrollo)",
+            "Información", JOptionPane.INFORMATION_MESSAGE);
+    }
+    
+    private void abrirGestionAudiencias() {
+        JOptionPane.showMessageDialog(this,
+            "Módulo de Gestión de Audiencias\n(En desarrollo)",
+            "Información", JOptionPane.INFORMATION_MESSAGE);
+    }
+    
+    private void abrirReportes() {
+        JOptionPane.showMessageDialog(this,
+            "Módulo de Reportes\n(En desarrollo)",
+            "Información", JOptionPane.INFORMATION_MESSAGE);
+    }
+    
+    private void abrirConfiguracion() {
+        ConfiguracionConexion configDialog = new ConfiguracionConexion(this);
+        configDialog.setVisible(true);
+    }
+    
+    private void generarReporteClientes() {
+        JOptionPane.showMessageDialog(this,
+            "Generando Reporte de Clientes...\n(En desarrollo)",
+            "Información", JOptionPane.INFORMATION_MESSAGE);
+    }
+    
+    private void generarReporteCasos() {
+        JOptionPane.showMessageDialog(this,
+            "Generando Reporte de Casos...\n(En desarrollo)",
+            "Información", JOptionPane.INFORMATION_MESSAGE);
+    }
+    
+    private void generarReporteGeneral() {
+        JOptionPane.showMessageDialog(this,
+            "Generando Reporte General...\n(En desarrollo)",
+            "Información", JOptionPane.INFORMATION_MESSAGE);
+    }
+    
+    private void mostrarAcercaDe() {
+        JOptionPane.showMessageDialog(this,
+            "Sistema de Buffet de Abogados v1.0\n" +
+            "Desarrollado en Java con Swing\n" +
+            "Arquitectura MVC\n\n" +
+            "© 2024 - Todos los derechos reservados",
+            "Acerca de", JOptionPane.INFORMATION_MESSAGE);
+    }
+    
+    private void cerrarSesion() {
+        int opcion = JOptionPane.showConfirmDialog(this,
+            "¿Está seguro que desea cerrar sesión?",
+            "Confirmar", JOptionPane.YES_NO_OPTION);
+        
+        if (opcion == JOptionPane.YES_OPTION) {
+            this.dispose();
+            new Login();
+        }
+    }
+}

--- a/BuffetAbogados/src/main/java/vista/RegistroUsuario.java
+++ b/BuffetAbogados/src/main/java/vista/RegistroUsuario.java
@@ -1,0 +1,416 @@
+package buffetabogados.vista;
+
+import buffetabogados.modelo.Usuario;
+import buffetabogados.controlador.LoginController;
+import buffetabogados.util.Validaciones;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/**
+ * Ventana para registro de nuevos usuarios
+ */
+public class RegistroUsuario extends JDialog {
+    
+    private JTextField txtNombres;
+    private JTextField txtApellidos;
+    private JTextField txtUsuario;
+    private JPasswordField txtPassword;
+    private JPasswordField txtConfirmarPassword;
+    private JComboBox<String> cmbRol;
+    private JButton btnRegistrar;
+    private JButton btnCancelar;
+    private JLabel lblEstado;
+    
+    private LoginController controller;
+    private JFrame parent;
+    
+    public RegistroUsuario(JFrame parent) {
+        super(parent, "Registro de Usuario", true);
+        this.parent = parent;
+        this.controller = new LoginController((Login) parent);
+        
+        inicializarComponentes();
+        configurarLayout();
+        configurarEventos();
+        
+        setSize(450, 400);
+        setLocationRelativeTo(parent);
+        setResizable(false);
+    }
+    
+    private void inicializarComponentes() {
+        // Campos de texto
+        txtNombres = new JTextField(20);
+        txtApellidos = new JTextField(20);
+        txtUsuario = new JTextField(20);
+        txtPassword = new JPasswordField(20);
+        txtConfirmarPassword = new JPasswordField(20);
+        
+        // ComboBox para rol
+        String[] roles = {"Cliente", "Empleado", "Abogado"};
+        cmbRol = new JComboBox<>(roles);
+        cmbRol.setSelectedIndex(0); // Cliente por defecto
+        
+        // Botones
+        btnRegistrar = new JButton("Registrar");
+        btnCancelar = new JButton("Cancelar");
+        
+        // Label de estado
+        lblEstado = new JLabel("Complete todos los campos para registrarse");
+        lblEstado.setForeground(Color.BLUE);
+        lblEstado.setHorizontalAlignment(SwingConstants.CENTER);
+        
+        // Configurar botón registrar como predeterminado
+        getRootPane().setDefaultButton(btnRegistrar);
+    }
+    
+    private void configurarLayout() {
+        setLayout(new BorderLayout());
+        
+        // Panel principal
+        JPanel panelPrincipal = new JPanel(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(8, 8, 8, 8);
+        gbc.anchor = GridBagConstraints.WEST;
+        
+        // Título
+        JLabel lblTitulo = new JLabel("REGISTRO DE USUARIO");
+        lblTitulo.setFont(new Font("Arial", Font.BOLD, 16));
+        lblTitulo.setForeground(new Color(0, 102, 204));
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        gbc.gridwidth = 2;
+        gbc.anchor = GridBagConstraints.CENTER;
+        panelPrincipal.add(lblTitulo, gbc);
+        
+        // Separador
+        JSeparator separador = new JSeparator();
+        gbc.gridy = 1;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        panelPrincipal.add(separador, gbc);
+        
+        // Nombres
+        gbc.gridwidth = 1;
+        gbc.fill = GridBagConstraints.NONE;
+        gbc.gridy = 2;
+        gbc.anchor = GridBagConstraints.EAST;
+        panelPrincipal.add(new JLabel("Nombres:*"), gbc);
+        
+        gbc.gridx = 1;
+        gbc.anchor = GridBagConstraints.WEST;
+        panelPrincipal.add(txtNombres, gbc);
+        
+        // Apellidos
+        gbc.gridx = 0;
+        gbc.gridy = 3;
+        gbc.anchor = GridBagConstraints.EAST;
+        panelPrincipal.add(new JLabel("Apellidos:*"), gbc);
+        
+        gbc.gridx = 1;
+        gbc.anchor = GridBagConstraints.WEST;
+        panelPrincipal.add(txtApellidos, gbc);
+        
+        // Usuario
+        gbc.gridx = 0;
+        gbc.gridy = 4;
+        gbc.anchor = GridBagConstraints.EAST;
+        panelPrincipal.add(new JLabel("Usuario:*"), gbc);
+        
+        gbc.gridx = 1;
+        gbc.anchor = GridBagConstraints.WEST;
+        panelPrincipal.add(txtUsuario, gbc);
+        
+        // Contraseña
+        gbc.gridx = 0;
+        gbc.gridy = 5;
+        gbc.anchor = GridBagConstraints.EAST;
+        panelPrincipal.add(new JLabel("Contraseña:*"), gbc);
+        
+        gbc.gridx = 1;
+        gbc.anchor = GridBagConstraints.WEST;
+        panelPrincipal.add(txtPassword, gbc);
+        
+        // Confirmar contraseña
+        gbc.gridx = 0;
+        gbc.gridy = 6;
+        gbc.anchor = GridBagConstraints.EAST;
+        panelPrincipal.add(new JLabel("Confirmar:*"), gbc);
+        
+        gbc.gridx = 1;
+        gbc.anchor = GridBagConstraints.WEST;
+        panelPrincipal.add(txtConfirmarPassword, gbc);
+        
+        // Rol
+        gbc.gridx = 0;
+        gbc.gridy = 7;
+        gbc.anchor = GridBagConstraints.EAST;
+        panelPrincipal.add(new JLabel("Rol:"), gbc);
+        
+        gbc.gridx = 1;
+        gbc.anchor = GridBagConstraints.WEST;
+        panelPrincipal.add(cmbRol, gbc);
+        
+        // Estado
+        gbc.gridx = 0;
+        gbc.gridy = 8;
+        gbc.gridwidth = 2;
+        gbc.anchor = GridBagConstraints.CENTER;
+        panelPrincipal.add(lblEstado, gbc);
+        
+        // Panel de botones
+        JPanel panelBotones = new JPanel(new FlowLayout(FlowLayout.CENTER));
+        panelBotones.add(btnRegistrar);
+        panelBotones.add(btnCancelar);
+        
+        // Panel de ayuda
+        JPanel panelAyuda = new JPanel(new FlowLayout(FlowLayout.CENTER));
+        JLabel lblAyuda = new JLabel("Los campos marcados con * son obligatorios");
+        lblAyuda.setFont(new Font("Arial", Font.PLAIN, 10));
+        lblAyuda.setForeground(Color.GRAY);
+        panelAyuda.add(lblAyuda);
+        
+        add(panelPrincipal, BorderLayout.CENTER);
+        add(panelBotones, BorderLayout.SOUTH);
+        add(panelAyuda, BorderLayout.NORTH);
+    }
+    
+    private void configurarEventos() {
+        // Evento para botón registrar
+        btnRegistrar.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                registrarUsuario();
+            }
+        });
+        
+        // Evento para botón cancelar
+        btnCancelar.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                dispose();
+            }
+        });
+        
+        // Eventos de validación en tiempo real
+        txtNombres.addKeyListener(new java.awt.event.KeyAdapter() {
+            public void keyReleased(java.awt.event.KeyEvent evt) {
+                validarCampoEnTiempoReal();
+            }
+        });
+        
+        txtApellidos.addKeyListener(new java.awt.event.KeyAdapter() {
+            public void keyReleased(java.awt.event.KeyEvent evt) {
+                validarCampoEnTiempoReal();
+            }
+        });
+        
+        txtUsuario.addKeyListener(new java.awt.event.KeyAdapter() {
+            public void keyReleased(java.awt.event.KeyEvent evt) {
+                validarCampoEnTiempoReal();
+            }
+        });
+        
+        txtPassword.addKeyListener(new java.awt.event.KeyAdapter() {
+            public void keyReleased(java.awt.event.KeyEvent evt) {
+                validarCampoEnTiempoReal();
+            }
+        });
+        
+        txtConfirmarPassword.addKeyListener(new java.awt.event.KeyAdapter() {
+            public void keyReleased(java.awt.event.KeyEvent evt) {
+                validarCampoEnTiempoReal();
+            }
+        });
+    }
+    
+    private void validarCampoEnTiempoReal() {
+        String nombres = txtNombres.getText();
+        String apellidos = txtApellidos.getText();
+        String usuario = txtUsuario.getText();
+        String password = new String(txtPassword.getPassword());
+        String confirmarPassword = new String(txtConfirmarPassword.getPassword());
+        
+        // Validar que todos los campos estén completos
+        if (Validaciones.campoVacio(nombres) || Validaciones.campoVacio(apellidos) ||
+            Validaciones.campoVacio(usuario) || Validaciones.campoVacio(password) ||
+            Validaciones.campoVacio(confirmarPassword)) {
+            
+            lblEstado.setText("Complete todos los campos obligatorios");
+            lblEstado.setForeground(Color.ORANGE);
+            btnRegistrar.setEnabled(false);
+            return;
+        }
+        
+        // Validar formato de nombres
+        if (!Validaciones.nombreValido(nombres)) {
+            lblEstado.setText("Los nombres solo pueden contener letras y espacios");
+            lblEstado.setForeground(Color.RED);
+            btnRegistrar.setEnabled(false);
+            return;
+        }
+        
+        // Validar formato de apellidos
+        if (!Validaciones.nombreValido(apellidos)) {
+            lblEstado.setText("Los apellidos solo pueden contener letras y espacios");
+            lblEstado.setForeground(Color.RED);
+            btnRegistrar.setEnabled(false);
+            return;
+        }
+        
+        // Validar formato de usuario
+        if (!Validaciones.usuarioValido(usuario)) {
+            lblEstado.setText("El usuario debe tener al menos 3 caracteres (letras, números, _)");
+            lblEstado.setForeground(Color.RED);
+            btnRegistrar.setEnabled(false);
+            return;
+        }
+        
+        // Validar longitud de contraseña
+        if (!Validaciones.passwordValida(password)) {
+            lblEstado.setText("La contraseña debe tener al menos 6 caracteres");
+            lblEstado.setForeground(Color.RED);
+            btnRegistrar.setEnabled(false);
+            return;
+        }
+        
+        // Validar que las contraseñas coincidan
+        if (!password.equals(confirmarPassword)) {
+            lblEstado.setText("Las contraseñas no coinciden");
+            lblEstado.setForeground(Color.RED);
+            btnRegistrar.setEnabled(false);
+            return;
+        }
+        
+        // Si llegamos aquí, todo está válido
+        lblEstado.setText("✓ Formulario válido - Listo para registrar");
+        lblEstado.setForeground(Color.GREEN);
+        btnRegistrar.setEnabled(true);
+    }
+    
+    private void registrarUsuario() {
+        // Validar una vez más antes de registrar
+        if (!validarFormulario()) {
+            return;
+        }
+        
+        // Crear objeto usuario
+        Usuario nuevoUsuario = new Usuario(
+            txtNombres.getText().trim(),
+            txtApellidos.getText().trim(),
+            txtUsuario.getText().trim(),
+            new String(txtPassword.getPassword()),
+            (String) cmbRol.getSelectedItem()
+        );
+        
+        // Intentar registrar
+        boolean exito = controller.registrarUsuario(nuevoUsuario);
+        
+        if (exito) {
+            // Limpiar formulario
+            limpiarFormulario();
+            
+            // Cerrar ventana
+            dispose();
+        }
+    }
+    
+    private boolean validarFormulario() {
+        String nombres = txtNombres.getText().trim();
+        String apellidos = txtApellidos.getText().trim();
+        String usuario = txtUsuario.getText().trim();
+        String password = new String(txtPassword.getPassword());
+        String confirmarPassword = new String(txtConfirmarPassword.getPassword());
+        
+        // Validar campos obligatorios
+        if (Validaciones.campoVacio(nombres)) {
+            JOptionPane.showMessageDialog(this,
+                Validaciones.mensajeCampoVacio("Nombres"),
+                "Error", JOptionPane.ERROR_MESSAGE);
+            txtNombres.requestFocus();
+            return false;
+        }
+        
+        if (Validaciones.campoVacio(apellidos)) {
+            JOptionPane.showMessageDialog(this,
+                Validaciones.mensajeCampoVacio("Apellidos"),
+                "Error", JOptionPane.ERROR_MESSAGE);
+            txtApellidos.requestFocus();
+            return false;
+        }
+        
+        if (Validaciones.campoVacio(usuario)) {
+            JOptionPane.showMessageDialog(this,
+                Validaciones.mensajeCampoVacio("Usuario"),
+                "Error", JOptionPane.ERROR_MESSAGE);
+            txtUsuario.requestFocus();
+            return false;
+        }
+        
+        if (Validaciones.campoVacio(password)) {
+            JOptionPane.showMessageDialog(this,
+                Validaciones.mensajeCampoVacio("Contraseña"),
+                "Error", JOptionPane.ERROR_MESSAGE);
+            txtPassword.requestFocus();
+            return false;
+        }
+        
+        // Validar formatos
+        if (!Validaciones.nombreValido(nombres)) {
+            JOptionPane.showMessageDialog(this,
+                "Los nombres solo pueden contener letras y espacios",
+                "Error", JOptionPane.ERROR_MESSAGE);
+            txtNombres.requestFocus();
+            return false;
+        }
+        
+        if (!Validaciones.nombreValido(apellidos)) {
+            JOptionPane.showMessageDialog(this,
+                "Los apellidos solo pueden contener letras y espacios",
+                "Error", JOptionPane.ERROR_MESSAGE);
+            txtApellidos.requestFocus();
+            return false;
+        }
+        
+        if (!Validaciones.usuarioValido(usuario)) {
+            JOptionPane.showMessageDialog(this,
+                "El usuario debe contener al menos 3 caracteres (letras, números y guiones bajos)",
+                "Error", JOptionPane.ERROR_MESSAGE);
+            txtUsuario.requestFocus();
+            return false;
+        }
+        
+        if (!Validaciones.passwordValida(password)) {
+            JOptionPane.showMessageDialog(this,
+                "La contraseña debe tener al menos 6 caracteres",
+                "Error", JOptionPane.ERROR_MESSAGE);
+            txtPassword.requestFocus();
+            return false;
+        }
+        
+        // Validar que las contraseñas coincidan
+        if (!password.equals(confirmarPassword)) {
+            JOptionPane.showMessageDialog(this,
+                "Las contraseñas no coinciden",
+                "Error", JOptionPane.ERROR_MESSAGE);
+            txtConfirmarPassword.requestFocus();
+            return false;
+        }
+        
+        return true;
+    }
+    
+    private void limpiarFormulario() {
+        txtNombres.setText("");
+        txtApellidos.setText("");
+        txtUsuario.setText("");
+        txtPassword.setText("");
+        txtConfirmarPassword.setText("");
+        cmbRol.setSelectedIndex(0);
+        lblEstado.setText("Complete todos los campos para registrarse");
+        lblEstado.setForeground(Color.BLUE);
+        btnRegistrar.setEnabled(true);
+    }
+}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Recreates `RegistroUsuario.java` and `Dashboard.java` as they were accidentally deleted.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
These files are crucial for the user registration and the main application dashboard, which were inadvertently removed in a prior commit. This PR restores their functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-d86e137c-7d6a-4bae-bc52-044c02ab7427">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d86e137c-7d6a-4bae-bc52-044c02ab7427">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>